### PR TITLE
docs(query): make sure people use the right name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ yarn add gatsby-plugin-algolia
 
 ```js
 // gatsby-config.js
-const query = `{
+const myQuery = `{
   allSitePage {
     edges {
       node {
@@ -39,7 +39,7 @@ const query = `{
 
 const queries = [
   {
-    query,
+    query: myQuery,
     transformer: ({ data }) => data.allSitePage.edges.map(({ node }) => node), // optional
     indexName: 'index name to target', // overrides main index name, optional
   },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -20,12 +20,18 @@ exports.onPostBuild = async function(
     query,
     transformer = identity,
   }) {
+    if (!query) {
+      report.panic(`failed to index to Algolia. You did not give "query" to this query`)
+    }
     const index = client.initIndex(indexName);
     const tmpIndex = client.initIndex(`${indexName}_tmp`);
 
     await scopedCopyIndex(client, index, tmpIndex);
 
     const result = await graphql(query);
+    if (result.errors) {
+      report.panic(`failed to index to Algolia`, result.errors);
+    }
     const objects = transformer(result);
     const chunks = chunk(objects, chunkSize);
 


### PR DESCRIPTION
fixes #6 


1. makes documentation clearer and less likely to make the error of not providing a query
2. rethrow errors of graphql
3. throw an error if there's no query