### PR TITLE
Add query variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ALGOLIA_INDEX_NAME=XXX
 ```js
 require('dotenv').config({
   path: `.env.${process.env.NODE_ENV}`,
-})
+});
 
 // gatsby-config.js
 const myQuery = `{
@@ -64,13 +64,55 @@ module.exports = {
       options: {
         appId: process.env.ALGOLIA_APP_ID,
         apiKey: process.env.ALGOLIA_API_KEY,
-        indexName: "index name to target", // for all queries
+        indexName: 'index name to target', // for all queries
         queries,
         chunkSize: 10000, // default: 1000
       },
     },
   ],
 };
+```
+
+# Using variables
+
+Pass object to `queryVariables` containing all your possible variables
+
+```js
+const queries = [
+  {
+    query: myQuery,
+    queryVariables: { exampleVariable: 1 },
+    transformer: ({ data }) => data.allSitePage.edges.map(({ node }) => node), // optional
+    indexName: 'index name to target', // overrides main index name, optional
+  },
+];
+```
+
+Update your query to accept the variable(s)
+
+```js
+const myQuery = `query($exampleVariable: Int!) {
+  allSitePage(skip: $exampleVariable) {
+    edges {
+      node {
+        # try to find a unique id for each node
+        # if this field is absent, it's going to
+        # be inserted by Algolia automatically
+        # and will be less simple to update etc.
+        objectID: id
+        component
+        path
+        componentChunkName
+        jsonName
+        internal {
+          type
+          contentDigest
+          owner
+        }
+      }
+    }
+  }
+}`;
 ```
 
 # Feedback

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -20,7 +20,13 @@ exports.onPostBuild = async function(
   setStatus(activity, `${queries.length} queries to index`);
 
   const jobs = queries.map(async function doQuery(
-    { indexName = mainIndexName, query, transformer = identity, settings },
+    {
+      indexName = mainIndexName,
+      query,
+      queryVariables,
+      transformer = identity,
+      settings,
+    },
     i
   ) {
     if (!query) {
@@ -39,7 +45,7 @@ exports.onPostBuild = async function(
     }
 
     setStatus(activity, `query ${i}: executing query`);
-    const result = await graphql(query);
+    const result = await graphql(query, queryVariables);
     if (result.errors) {
       report.panic(`failed to index to Algolia`, result.errors);
     }


### PR DESCRIPTION
motivation: 
we have a multi language website and as I understood the best practice is to create multiple indices per language, and then in the front-end to target the specific index by locale name.

problem:
```
query($locale: String){
  contentful {
    urlSlugCollection(locale: $locale) {
      items {
        sys {
          id
        }
        slug
        pageTitle
      }
    }
  }
}
```
Performing this query needs a variable `locale` in order to be able to fetch the correct localised data from the slugs(this is just an example query). 

Currently there is no support for `variables` which this PR aims to add.

Looking forward to your review and suggestions.

related to: #8 