### PR TITLE
Don't publish examples to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-example

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+example

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   },
   "scripts": {
     "release": "standard-version"
-  }
+  },
+  "files": [
+    "gatsby-node.js"
+  ]
 }


### PR DESCRIPTION
As of `gatsby@2.12.1` (https://github.com/gatsbyjs/gatsby/pull/15284), we now parse GraphQL queries in dependencies to enable packages to ship queries! 

The examples in this repo however interfere with this and cause this package to break (details in https://github.com/gatsbyjs/gatsby/issues/15344) 

We highly recommend not shipping examples to `npm` and this PR fixes this by adding it to .npmignore

Cheers from the gatsby team!