### PR TITLE
add await to setSettings call

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -56,7 +56,7 @@ exports.onPostBuild = async function(
     await Promise.all(chunkJobs);
 
     if (settings) {
-      indexToUse.setSettings(settings);
+      await indexToUse.setSettings(settings);
     }
 
     if (mainIndexExists) {


### PR DESCRIPTION
This fixes #37 

Without the `await`, the `setSettings` call sometimes succeeded before the `moveIndex` and sometimes did not. This race condition caused irregular updates to indices.