### PR TITLE
Accounts for replica indices

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -65,11 +65,12 @@ exports.onPostBuild = async function(
       // Account for forwardToReplicas:
       const extraModifiers = forwardToReplicas ? { forwardToReplicas } : {};
 
+      const { replicas, ...rest } = settings;
+      
       let adjustedSettings = settings;
 
       // If we're building replicas, we don't want to add them to temporary indices
-      if (indexToUse === tmpIndex && settings.hasOwnProperty('replicas')) {
-        const { replicas, ...rest } = settings;
+      if (indexToUse === tmpIndex) {
         adjustedSettings = { ...rest };
       }
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -37,7 +37,7 @@ exports.onPostBuild = async function(
     const index = client.initIndex(indexName);
     const mainIndexExists = await indexExists(index);
     const tmpIndex = client.initIndex(`${indexName}_tmp`);
-    let indexToUse = mainIndexExists ? tmpIndex : index;
+    const indexToUse = mainIndexExists ? tmpIndex : index;
 
     if (mainIndexExists) {
       setStatus(activity, `query ${i}: copying existing index`);
@@ -66,7 +66,7 @@ exports.onPostBuild = async function(
       const extraModifiers = forwardToReplicas ? { forwardToReplicas } : {};
 
       const { replicas, ...rest } = settings;
-      
+
       let adjustedSettings = settings;
 
       // If we're building replicas, we don't want to add them to temporary indices

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -65,19 +65,14 @@ exports.onPostBuild = async function(
       // Account for forwardToReplicas:
       const extraModifiers = forwardToReplicas ? { forwardToReplicas } : {};
 
-      const { replicas, ...rest } = settings;
-
-      let adjustedSettings = settings;
-
       // If we're building replicas, we don't want to add them to temporary indices
-      if (indexToUse === tmpIndex) {
-        adjustedSettings = { ...rest };
-      }
+      const { replicas, ...adjustedSettings } = settings;
 
       const { taskID } = await indexToUse.setSettings(
-        adjustedSettings,
+        indexToUse === tmpIndex ? adjustedSettings : settings,
         extraModifiers
       );
+      
       await indexToUse.waitTask(taskID);
     }
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -56,7 +56,7 @@ exports.onPostBuild = async function(
     await Promise.all(chunkJobs);
 
     if (settings) {
-      indexToUse.setSettings(settings);
+      await indexToUse.setSettings(settings);
     }
 
     if (mainIndexExists) {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -65,12 +65,13 @@ exports.onPostBuild = async function(
     await Promise.all(chunkJobs);
 
     if (settings) {
+      // Account for forwardToReplicas:
       const extraModifiers = forwardToReplicas ? { forwardToReplicas } : {};
 
       let adjustedSettings = {};
+      
+      // If we're building replicas, we don't want to add them to temporary indices
       if (currentIndexIsTempIndex && settings.hasOwnProperty('replicas')) {
-        // if settings has `replicas` and indexToUse is a temp
-        // don't add the replicas array to the index
         const { replicas, ...rest } = settings;
         adjustedSettings = { ...rest };
       } else {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -20,7 +20,13 @@ exports.onPostBuild = async function(
   setStatus(activity, `${queries.length} queries to index`);
 
   const jobs = queries.map(async function doQuery(
-    { indexName = mainIndexName, query, transformer = identity, settings, forwardToReplicas },
+    {
+      indexName = mainIndexName,
+      query,
+      transformer = identity,
+      settings,
+      forwardToReplicas,
+    },
     i
   ) {
     if (!query) {
@@ -69,7 +75,7 @@ exports.onPostBuild = async function(
       const extraModifiers = forwardToReplicas ? { forwardToReplicas } : {};
 
       let adjustedSettings = {};
-      
+
       // If we're building replicas, we don't want to add them to temporary indices
       if (currentIndexIsTempIndex && settings.hasOwnProperty('replicas')) {
         const { replicas, ...rest } = settings;
@@ -136,10 +142,11 @@ async function moveIndex(client, sourceIndex, targetIndex) {
  * @param index
  */
 function indexExists(index) {
-  return index.getSettings()
+  return index
+    .getSettings()
     .then(() => true)
     .catch(error => {
-      if (error.status !== 404) {
+      if (error.statusCode !== 404) {
         throw error;
       }
 


### PR DESCRIPTION
The basic premise of this issue was that I kept getting an error saying `A replica index is already replica of another index` whenever I tried to pass queries into this plugin that contained a replicas array within their `settings` object. 

**I found that a solution was to prevent the plugin from trying to attach replica indices to a `_tmp` index.**

I also found that in `indexExists`, `error.status` needed to be switched to `error.statusCode`... apparently `error.status` was not returning an accurate status code...

I also found that `forwardToReplicas` was not supported... so, I implemented a quick solution to pass it through to Algolia. In the future, I'm assuming other modifiers will need to be added... So, I created an `extraModifiers` object to allow for additional property additions, later on.

Fixes: https://github.com/algolia/gatsby-plugin-algolia/issues/49