### PR TITLE
fix: allow "id" instead of "objectID" again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea

--- a/example/gatsby-config.js
+++ b/example/gatsby-config.js
@@ -11,7 +11,6 @@ const query = `{
         # be inserted by Algolia automatically
         # and will be less simple to update etc.
         objectID: id
-        updated
         component
         path
         componentChunkName
@@ -28,7 +27,6 @@ const query = `{
 
 const queries = [
   {
-    indexName: `pages`,
     query,
     transformer: ({ data }) => data.allSitePage.edges.map(({ node }) => node), // optional
     settings: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -100,12 +100,6 @@ exports.onPostBuild = async function (
 
     const objects = await transformer(result);
 
-    if (objects.length > 0 && !objects[0].objectID) {
-      report.panic(
-        `failed to index to Algolia. Query results do not have 'objectID' key`
-      );
-    }
-
     setStatus(
       activity,
       `query ${i}: graphql resulted in ${Object.keys(objects).length} records`
@@ -124,23 +118,29 @@ exports.onPostBuild = async function (
         `query ${i}: found ${nbMatchedRecords} existing records`
       );
 
+      if(objects.length > 0 && !objects[0].objectID && objects[0].id){
+        objects.map(curObj => curObj.objectID = curObj.id)
+      }
+
       if (nbMatchedRecords) {
-        hasChanged = objects.filter((curObj) => {
-          const ID = curObj.objectID;
-          let extObj = algoliaObjects[ID];
+        if (objects.length > 0 && objects[0].objectID) {
+          hasChanged = objects.filter((curObj) => {
+            const ID = curObj.objectID || curObj.id;
+            let extObj = algoliaObjects[ID];
 
-          /* The object exists so we don't need to remove it from Algolia */
-          delete algoliaObjects[ID];
-          delete currentIndexState.toRemove[ID];
+            /* The object exists so we don't need to remove it from Algolia */
+            delete algoliaObjects[ID];
+            delete currentIndexState.toRemove[ID];
 
-          if (!extObj) return true;
+            if (!extObj) return true;
 
-          return !!matchFields.find((field) => extObj[field] !== curObj[field]);
-        });
+            return !!matchFields.find((field) => extObj[field] !== curObj[field]);
+          });
 
-        Object.keys(algoliaObjects).forEach(
-          ({ objectID }) => (currentIndexState.toRemove[objectID] = true)
-        );
+          Object.keys(algoliaObjects).forEach(
+            ({ objectID }) => (currentIndexState.toRemove[objectID] = true)
+          );
+        }
       }
 
       setStatus(


### PR DESCRIPTION
Since it accepted the `objectID` not coming before, it started to receive an error in cases where the `objectID` was not passed from `version 0.8`.

I think this should be true even if the `objectID` is not correct to be managed by algolia.

It should also accept the default id bypassing the `objectID`.

For this, if the `objectID` or `id` is missing, I let it add normally without comparison. I also copied it to use it as an `objectID` if id came.

fixes #55