### PR TITLE
fix: improve error message when index can not be found

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -82,6 +82,11 @@ exports.onPostBuild = async function (
       tempIndex,
       enablePartialUpdates,
     });
+    if (!indexToUse) {
+      report.panic(
+        `The index you specified ("${indexName}") can not be found. Please log in to your Algolia dashboard and create it.`
+      );
+    }
 
     /* Use to keep track of what to remove afterwards */
     if (!indexState[indexName]) {


### PR DESCRIPTION
Currently, the error looks like this:

<img width="608" alt="joscha_Joschas-MacBook-Pro____work_docs_eng-curriculum" src="https://user-images.githubusercontent.com/188038/80710588-56da6380-8b32-11ea-98f2-0de078893b65.png">

I found this issue after myself and a bit of googling showed I am not the only one: https://stackoverflow.com/questions/61521867/why-did-i-fail-to-index-to-algolia/61523372#61523372