### PR TITLE
fix: return the index created

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -275,14 +275,17 @@ function setStatus(activity, status) {
 }
 
 async function getIndexToUse({ index, tempIndex, enablePartialUpdates }) {
-  if (enablePartialUpdates) {
-    return index;
+  const mainIndexExists = await indexExists(index);
+
+  if (enablePartialUpdates && !mainIndexExists) {
+    return createIndex(index);
   }
 
-  const mainIndexExists = await indexExists(index);
-  if (mainIndexExists) {
+  if (!enablePartialUpdates && mainIndexExists) {
     return tempIndex;
   }
+
+  return index;
 }
 
 async function getSettingsToApply({ settings, index, tempIndex, indexToUse }) {
@@ -295,4 +298,10 @@ async function getSettingsToApply({ settings, index, tempIndex, indexToUse }) {
   }
 
   return requestedSettings;
+}
+
+async function createIndex(index) {
+  const { taskID } = await index.setSettings({});
+  await index.waitTask(taskID);
+  return index;
 }


### PR DESCRIPTION
Closes #52 (I hope)

This PR aims to fix an issue with the option `partialUpdates` enabled. Today, when the index doesn't exist the plugin, throws an error: "Index test_does_not_exist does not exist" because we can't browse on an index that doesn't exist.

One possible solution is to _force_ the creation of the index. We avoid more branches in the code and we follow the same logic when the index exists or doesn't exist. To force the creation of the index we use an empty `setSettings + waitTask` to ensure the index is created when we exit the function i.e. safe to browse. The index doesn't exist so the empty `setSettings` call shouldn't remove settings but create the index.

This change also fixes the issue described in https://github.com/algolia/gatsby-plugin-algolia/pull/60#issuecomment-621912826 because now we fall-back to `index` when: `partialUpdates` is disabled and the index doesn't exist, `partialUpdates` is enabled and the index exists.

Here is what happens without the fix with `partialUpdates` enabled without the index:

```
$ gatsby build
⠁ Algolia: 1 queries to index
Algolia: query 0: executing query
Algolia: query 0: graphql resulted in 5 records
Algolia: query 0: starting Partial updates
error failed to index to Algolia

  AlgoliaSearchError: Index test_does_not_exist does not exist

  - AlgoliaSearchCore.js:351 success
    [gatsby-plugin-algolia]/[algoliasearch]/src/AlgoliaSearchCore.js:351:32

  - util.js:16 tryCatcher
    [example]/[bluebird]/js/release/util.js:16:23

  - promise.js:512 Promise._settlePromiseFromHandler
    [example]/[bluebird]/js/release/promise.js:512:31

  - promise.js:569 Promise._settlePromise
    [example]/[bluebird]/js/release/promise.js:569:18

  - promise.js:614 Promise._settlePromise0
    [example]/[bluebird]/js/release/promise.js:614:10

  - promise.js:694 Promise._settlePromises
    [example]/[bluebird]/js/release/promise.js:694:18

  - async.js:138 _drainQueueStep
    [example]/[bluebird]/js/release/async.js:138:12

  - async.js:131 _drainQueue
    [example]/[bluebird]/js/release/async.js:131:9

  - async.js:147 Async._drainQueues
    [example]/[bluebird]/js/release/async.js:147:5

  - async.js:17 Immediate.Async.drainQueues [as _onImmediate]
    [example]/[bluebird]/js/release/async.js:17:14
```

With the fix the build completes:

```
$ gatsby build
Algolia: 1 queries to index
index to AlgoliaAlgolia: query 0: executing query
index to AlgoliaAlgolia: query 0: graphql resulted in 5 records
Algolia: query 0: starting Partial updates
Algolia: query 0: found 0 existing records
Algolia: query 0: Partial updates – [insert/update: 5, total: 5]
Algolia: query 0: splitting in 1 jobs
success index to Algolia — 3.122 s
info Done building in 13.755 sec
```

----

Here is what happens without the fix with `partialUpdates` disabled without the index:

```
$ gatsby build
Algolia: 1 queries to index
index to AlgoliaAlgolia: query 0: executing query
Algolia: query 0: graphql resulted in 5 records
Algolia: query 0: splitting in 1 jobs
error failed to index to Algolia


  TypeError: Cannot read property 'addObjects' of undefined

  - gatsby-node.js:161
    /Users/samuelvaillant/Work/gatsby-plugin-algolia/gatsby-node.js:161:43

  - Array.map

  - gatsby-node.js:160 doQuery
    /Users/samuelvaillant/Work/gatsby-plugin-algolia/gatsby-node.js:160:30
```

With the fix the build completes:

```
$ gatsby build
Algolia: 1 queries to index
index to AlgoliaAlgolia: query 0: executing query
Algolia: query 0: graphql resulted in 5 records
Algolia: query 0: splitting in 1 jobs
success index to Algolia — 1.981 s
info Done building in 14.96 sec
```

cc @Haroenv 