### PR TITLE
[fix] Fix async issue with transformer

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -99,7 +99,7 @@ exports.onPostBuild = async function (
       report.panic(`failed to index to Algolia`, result.errors);
     }
 
-    const objects = await transformer(result).map((object) => ({
+    const objects = (await transformer(result)).map((object) => ({
       objectID: object.objectID || object.id,
       ...object,
     }));


### PR DESCRIPTION
When passing an async function, you will get the error
`TypeError: transformer(...).map is not a function`
which is correct becuse `Promise.map` is not a function.
Adding the parentheses will execute the async transformer,
and then apply `.map` to the array returned

Addesses issue: https://github.com/algolia/gatsby-plugin-algolia/issues/73