### PR TITLE
chore: update message to clearly indicate the index of query

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -93,7 +93,7 @@ exports.onPostBuild = async function (
     }
     const currentIndexState = indexState[indexName];
 
-    setStatus(activity, `query #${i}: executing query`);
+    setStatus(activity, `query #${i + 1}: executing query`);
     const result = await graphql(query);
     if (result.errors) {
       report.panic(`failed to index to Algolia`, result.errors);

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -93,7 +93,7 @@ exports.onPostBuild = async function (
     }
     const currentIndexState = indexState[indexName];
 
-    setStatus(activity, `query ${i}: executing query`);
+    setStatus(activity, `query #${i}: executing query`);
     const result = await graphql(query);
     if (result.errors) {
       report.panic(`failed to index to Algolia`, result.errors);


### PR DESCRIPTION
When only one query is configured, what people see is `Algolia: query 0: executing query` and it might make them think "zero query" has been executed.

Not sure between `#0` vs `#1`