### PR TITLE
fix: remove deleted records

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -143,7 +143,7 @@ exports.onPostBuild = async function (
         });
 
         Object.keys(algoliaObjects).forEach(
-          ({ objectID }) => (currentIndexState.toRemove[objectID] = true)
+          objectID => (currentIndexState.toRemove[objectID] = true)
         );
       }
 


### PR DESCRIPTION
closes #82

Previously, when using `enablePartialUpdates`, deleted records would not be removed from Algolia. It seems like this bug was caused by a very small typo which this PR fixes.