### PR TITLE
fix: define variable for fields check

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -135,7 +135,7 @@ exports.onPostBuild = async function (
 
       if (nbMatchedRecords) {
         hasChanged = objects.filter(curObj => {
-          if (matchFields.every(curObj => Boolean(curObj[field]) === false)) {
+          if (matchFields.every(field => Boolean(curObj[field]) === false)) {
             report.panic(
               'when enablePartialUpdates is true, the objects must have at least one of the match fields. Current object:\n' +
                 JSON.stringify(curObj, null, 2) +


### PR DESCRIPTION
In version 0.12.0, the `field` variable was undefined, which caused builds to fail. Defining the variable as I hope it was intended.