### PR TITLE
feat(indexing): allow plugin to work with repeated single index in queries by batching

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -127,7 +127,7 @@ function groupQueriesByIndex(queries = [], config) {
 }
 
 /**
- * FIXME
+ * Run all queries for a given index, then make any updates / removals necessary
  */
 async function runIndexQueries(
   indexName,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,13 +3,6 @@ const chunk = require('lodash.chunk');
 const report = require('gatsby-cli/lib/reporter');
 
 /**
- * give back the same thing as this was called with.
- *
- * @param {any} obj what to keep the same
- */
-const identity = obj => obj;
-
-/**
  * Fetches all records for the current index from Algolia
  *
  * @param {AlgoliaIndex} index eg. client.initIndex('your_index_name');
@@ -32,14 +25,8 @@ function fetchAlgoliaObjects(index, attributesToRetrieve = ['modified']) {
   });
 }
 
-exports.onPostBuild = async function ({ graphql }, options) {
-  const {
-    appId,
-    apiKey,
-    queries,
-    enablePartialUpdates = false,
-    concurrentQueries = true,
-  } = options;
+exports.onPostBuild = async function ({ graphql }, config) {
+  const { appId, apiKey, queries, concurrentQueries = true } = config;
 
   const activity = report.activityTimer(`index to Algolia`);
   activity.start();
@@ -49,15 +36,16 @@ exports.onPostBuild = async function ({ graphql }, options) {
   setStatus(activity, `${queries.length} queries to index`);
 
   try {
+    // combine queries with the same index to prevent overwriting data
+    const groupedQueries = groupQueriesByIndex(queries, config);
+
     const jobs = [];
-    for (const [queryIndex, queryOptions] of queries.entries()) {
-      const queryPromise = doQuery({
+    for (const [indexName, indexQueries] of Object.entries(groupedQueries)) {
+      const queryPromise = runIndexQueries(indexName, indexQueries, {
         client,
         activity,
-        queryOptions,
-        queryIndex,
         graphql,
-        options,
+        config,
       });
 
       if (concurrentQueries) {
@@ -69,112 +57,14 @@ exports.onPostBuild = async function ({ graphql }, options) {
       }
     }
 
-    const jobResults = await Promise.all(jobs);
-
-    if (enablePartialUpdates) {
-      // Combine queries with the same index
-      const cleanupJobs = jobResults.reduce((acc, { index, toRemove = {} }) => {
-        const indexName = index.indexName;
-        if (acc.hasOwnProperty(indexName)) {
-          // If index already exists, combine fields to remove
-          return {
-            ...acc,
-            [indexName]: {
-              ...acc[indexName],
-              toRemove: {
-                ...acc[indexName].toRemove,
-                ...toRemove,
-              },
-            },
-          };
-        } else {
-          return {
-            ...acc,
-            [indexName]: {
-              index,
-              toRemove,
-            },
-          };
-        }
-      }, {});
-
-      const cleanup = Object.keys(cleanupJobs).map(async function (indexName) {
-        const { index, toRemove } = cleanupJobs[indexName];
-        const isRemoved = Object.keys(toRemove);
-
-        if (isRemoved.length) {
-          setStatus(
-            activity,
-            `deleting ${isRemoved.length} objects from ${indexName} index`
-          );
-          const { taskID } = await index.deleteObjects(isRemoved);
-          return index.waitTask(taskID);
-        }
-      });
-
-      await Promise.all(cleanup);
-    }
+    await Promise.all(jobs);
   } catch (err) {
     report.panic('failed to index to Algolia', err);
   }
   activity.end();
 };
 
-/**
- * Runs as individual query and updates the corresponding index on Algolia
- */
-async function doQuery({
-  client,
-  activity,
-  queryOptions,
-  queryIndex,
-  options,
-  graphql,
-}) {
-  const {
-    settings: mainSettings,
-    indexName: mainIndexName,
-    chunkSize = 1000,
-    enablePartialUpdates = false,
-    matchFields: mainMatchFields = ['modified'],
-  } = options;
-
-  const {
-    indexName = mainIndexName,
-    query,
-    transformer = identity,
-    settings = mainSettings,
-    forwardToReplicas,
-    matchFields = mainMatchFields,
-  } = queryOptions;
-
-  const setQueryStatus = status => {
-    setStatus(activity, `Query #${queryIndex + 1} (${indexName}): ${status}`);
-  };
-
-  if (!query) {
-    report.panic(
-      `failed to index to Algolia. You did not give "query" to this query`
-    );
-  }
-  if (!Array.isArray(matchFields) || !matchFields.length) {
-    return report.panic(
-      `failed to index to Algolia. Argument matchFields has to be an array of strings`
-    );
-  }
-
-  const index = client.initIndex(indexName);
-  const tempIndex = client.initIndex(`${indexName}_tmp`);
-  const indexToUse = await getIndexToUse({
-    index,
-    tempIndex,
-    enablePartialUpdates,
-  });
-
-  /* Use to keep track of what to remove afterwards */
-  const toRemove = {};
-
-  setQueryStatus('Executing query...');
+async function getObjectsMapByQuery({ query, transformer }, graphql) {
   const result = await graphql(query);
   if (result.errors) {
     report.panic(
@@ -194,60 +84,179 @@ async function doQuery({
     );
   }
 
-  setQueryStatus(`graphql resulted in ${objects.length} records`);
+  // return a map by id for later use
+  return objects.reduce((acc, object = {}) => {
+    return {
+      ...acc,
+      [object.objectID]: object,
+    };
+  }, {});
+}
 
-  let hasChanged = objects;
-  if (enablePartialUpdates) {
-    setQueryStatus(`Starting Partial updates...`);
+// get all match fields for all queries to minimize calls to the api
+function getAllMatchFields(queries, mainMatchFields = []) {
+  const allMatchFields = [...mainMatchFields];
 
-    const algoliaObjects = await fetchAlgoliaObjects(indexToUse, matchFields);
+  queries.forEach(({ matchFields = [] }) => {
+    matchFields.forEach(field => {
+      if (!allMatchFields.includes(field)) {
+        allMatchFields.push(field);
+      }
+    });
+  });
 
-    const nbMatchedRecords = Object.keys(algoliaObjects).length;
-    setQueryStatus(`Found ${nbMatchedRecords} existing records`);
+  return allMatchFields;
+}
 
-    if (nbMatchedRecords) {
-      hasChanged = objects.filter(curObj => {
-        if (matchFields.every(field => Boolean(curObj[field]) === false)) {
-          report.panic(
-            'when enablePartialUpdates is true, the objects must have at least one of the match fields. Current object:\n' +
-              JSON.stringify(curObj, null, 2) +
-              '\n' +
-              'expected one of these fields:\n' +
-              matchFields.join('\n')
-          );
-        }
+function groupQueriesByIndex(queries = [], config) {
+  const { indexName: mainIndexName } = config;
 
-        const ID = curObj.objectID;
-        let extObj = algoliaObjects[ID];
+  return queries.reduce((groupedQueries, queryOptions) => {
+    const { indexName = mainIndexName } = queryOptions;
 
-        /* The object exists so we don't need to remove it from Algolia */
-        delete algoliaObjects[ID];
-        delete toRemove[ID];
+    return {
+      ...groupedQueries,
+      [indexName]: [
+        ...(groupedQueries.hasOwnProperty(indexName)
+          ? groupedQueries[indexName]
+          : []),
+        queryOptions,
+      ],
+    };
+  }, {});
+}
 
-        if (!extObj) return true;
+/**
+ * FIXME
+ */
+async function runIndexQueries(
+  indexName,
+  queries = [],
+  { client, activity, graphql, config }
+) {
+  const {
+    settings: mainSettings,
+    chunkSize = 1000,
+    enablePartialUpdates = false,
+    matchFields: mainMatchFields = ['modified'],
+  } = config;
 
-        return matchFields.some(field => extObj[field] !== curObj[field]);
-      });
+  setStatus(
+    activity,
+    `Running ${queries.length} ${
+      queries.length === 1 ? 'query' : 'queries'
+    } for index ${indexName}...`
+  );
 
-      Object.keys(algoliaObjects).forEach(objectID => {
-        // if the object has one of the matchFields, it should be removed,
-        // but objects without matchFields are considered "not controlled"
-        // and stay in the index
-        if (matchFields.some(field => algoliaObjects[objectID][field])) {
-          toRemove[objectID] = true;
-        }
-      });
-    }
+  const objectMapsByQuery = await Promise.all(
+    queries.map(query => getObjectsMapByQuery(query, graphql))
+  );
 
-    setQueryStatus(
-      `Partial updates – [insert/update: ${hasChanged.length}, total: ${objects.length}]`
+  const allObjectsMap = objectMapsByQuery.reduce((acc, objectsMap = {}) => {
+    return {
+      ...acc,
+      ...objectsMap,
+    };
+  }, {});
+
+  setStatus(
+    activity,
+    `${queries.length === 1 ? 'Query' : 'Queries'} resulted in a total of ${
+      Object.keys(allObjectsMap).length
+    } results`
+  );
+
+  const index = client.initIndex(indexName);
+  const tempIndex = client.initIndex(`${indexName}_tmp`);
+  const indexToUse = await getIndexToUse({
+    index,
+    tempIndex,
+    enablePartialUpdates,
+  });
+
+  let toIndex = {}; // used to track objects that should be added / updated
+  const toRemove = {}; // used to track objects that are stale and should be removed
+
+  // let objectsToIndex = [];
+
+  if (enablePartialUpdates !== true) {
+    // if enablePartialUpdates isn't true, so index all objects
+    toIndex = { ...allObjectsMap };
+    // objectsToIndex.push(...Object.values(allObjectsMap));
+  } else {
+    // iterate over each query to determine which data are fresh
+    setStatus(activity, `Starting Partial updates...`);
+
+    // get all match fields for all queries to minimize calls to the api
+    const allMatchFields = getAllMatchFields(queries, mainMatchFields);
+
+    // get all indexed objects matching all matched fields
+    const indexedObjects = await fetchAlgoliaObjects(
+      indexToUse,
+      allMatchFields
     );
+
+    // iterate over each query
+    for (const [i, { matchFields = mainMatchFields }] of queries.entries()) {
+      const queryObjectsMap = objectMapsByQuery[i] || {};
+
+      // iterate over existing objects and compare to fresh data
+      for (const [id, existingObj] of Object.entries(indexedObjects)) {
+        if (queryObjectsMap.hasOwnProperty(id)) {
+          // key matches fresh objects, so compare match fields
+          const newObj = queryObjectsMap[id];
+          if (!matchFields.every(field => newObj.hasOwnProperty(field))) {
+            report.panic(
+              'when enablePartialUpdates is true, the objects must have at least one of the match fields. Current object:\n' +
+                JSON.stringify(curObj, null, 2) +
+                '\n' +
+                'expected one of these fields:\n' +
+                matchFields.join('\n')
+            );
+          }
+
+          if (matchFields.some(field => existingObj[field] !== newObj[field])) {
+            // one or more fields differ, so index new object
+            toIndex[id] = newObj;
+            // objectsToIndex.push(newObj);
+          } else {
+            // objects are the same, so skip
+          }
+
+          // remove from queryObjectsMap, since it is already accounted for
+          delete queryObjectsMap[id];
+        } else {
+          // check if existing object exists in any new query
+          if (!allObjectsMap.hasOwnProperty(id)) {
+            // existing object not in new queries; remove
+            toRemove[id] = true;
+          }
+        }
+      }
+
+      if (Object.values(queryObjectsMap).length) {
+        // stale objects have been removed, remaining query objects should be indexed
+        // objectsToIndex.push(...freshObjects);
+        toIndex = {
+          ...toIndex,
+          ...queryObjectsMap,
+        };
+      }
+    }
   }
 
-  if (hasChanged.length) {
-    const chunks = chunk(hasChanged, chunkSize);
+  const objectsToIndex = Object.values(toIndex);
+  const objectsToRemove = Object.keys(toRemove);
 
-    setQueryStatus(`Splitting in ${chunks.length} jobs`);
+  if (objectsToIndex.length) {
+    const chunks = chunk(objectsToIndex, chunkSize);
+
+    setStatus(
+      activity,
+      `Found ${objectsToIndex.length} new / updated records...`
+    );
+
+    setStatus(activity, `Splitting in ${chunks.length} jobs`);
 
     /* Add changed / new objects */
     const chunkJobs = chunks.map(async function (chunked) {
@@ -257,8 +266,22 @@ async function doQuery({
 
     await Promise.all(chunkJobs);
   } else {
-    setQueryStatus('No changes; skipping');
+    setStatus(activity, `No updates necessary; skipping!`);
   }
+
+  if (objectsToRemove.length) {
+    setStatus(
+      activity,
+      `Found ${objectsToRemove.length} stale objects; removing...`
+    );
+
+    const { taskID } = await indexToUse.deleteObjects(objectsToRemove);
+    await indexToUse.waitTask(taskID);
+  }
+
+  // defer to first query for index settings
+  // todo: maybe iterate over all settings and throw if they differ
+  const { settings = mainSettings, forwardToReplicas } = queries[0] || {};
 
   if (settings) {
     const settingsToApply = await getSettingsToApply({
@@ -276,16 +299,10 @@ async function doQuery({
   }
 
   if (indexToUse === tempIndex) {
-    setQueryStatus('Moving copied index to main index...');
     await moveIndex(client, indexToUse, index);
   }
 
-  setQueryStatus('Done!');
-
-  return {
-    index,
-    toRemove,
-  };
+  setStatus(activity, 'Done!');
 }
 
 /**


### PR DESCRIPTION
I'm submitting this because I reworked a decent amount of the plugin to be compatible with multiple queries to the same index. It seems to work well for my use case but the diff is fairly gnarly so I'm not sure if you'd like to pull this in or not. I'm happy to rework anything if you are interested in merging, but if not I can just maintain my fork and use the patched version for my needs. Let me know what you think, thanks!