### PR TITLE
Update readme to use modern GraphQL query

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ You can specify a list of queries to run and how to transform them into an array
 Here we have an example with some data that might not be very relevant, but will work with the default configuration of `gatsby new`
 
 ```shell
-$ yarn add gatsby-plugin-algolia
+yarn add gatsby-plugin-algolia
 ```
 
 First add credentials to a .env file, which you won't commit. If you track this in your file, and especially if the site is open source, you will leak your admin API key. This would mean anyone is able to change anything on your Algolia index.
 
-```
+```shell
 // .env.production
 ALGOLIA_APP_ID=XXX
 ALGOLIA_API_KEY=XXX
@@ -28,23 +28,21 @@ require('dotenv').config({
 
 // gatsby-config.js
 const myQuery = `{
-  allSitePage {
-    edges {
-      node {
-        # try to find a unique id for each node
-        # if this field is absent, it's going to
-        # be inserted by Algolia automatically
-        # and will be less simple to update etc.
-        objectID: id
-        component
-        path
-        componentChunkName
-        jsonName
-        internal {
-          type
-          contentDigest
-          owner
-        }
+  pages: allSitePage {
+    nodes {
+      # try to find a unique id for each node
+      # if this field is absent, it's going to
+      # be inserted by Algolia automatically
+      # and will be less simple to update etc.
+      objectID: id
+      component
+      path
+      componentChunkName
+      jsonName
+      internal {
+        type
+        contentDigest
+        owner
       }
     }
   }
@@ -53,7 +51,7 @@ const myQuery = `{
 const queries = [
   {
     query: myQuery,
-    transformer: ({ data }) => data.allSitePage.edges.map(({ node }) => node), // optional
+    transformer: ({ data }) => data.pages.nodes, // optional
     indexName: 'index name to target', // overrides main index name, optional
     settings: {
       // optional, any index settings
@@ -132,8 +130,8 @@ Sometimes, on limited platforms like Netlify, concurrent queries to the same ind
 
 ## Transformer
 
-The `transformer` field accepts a function and optionally you may provide an `async` function. This is useful when you want to change e.g. "edges.node" to simply an array.
+The `transformer` field accepts a function and optionally you may provide an `async` function.
 
-# Feedback
+## Feedback
 
 This is the very first version of our plugin and isn't yet officially supported. Please leave all your feedback in GitHub issues 😊


### PR DESCRIPTION
In [v2.2.0](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/CHANGELOG.md#220-2019-03-19), Gatsby introduced `nodes` as a less verbose alternative to `edges { node }` in their GraphQL queries. See e.g. gatsbyjs/gatsby#21255 for details.