### PR TITLE
Specifiy what versions of node this package can build on

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "devDependencies": {
     "standard-version": "^4.4.0"
   },
+  "engines" : { 
+    "node" : ">=12.0.0" 
+  },
   "scripts": {
     "release": "standard-version"
   },


### PR DESCRIPTION
I ran into the same issue as #106 and think it might be better to specify the version of node this package requires in package.json. 

https://docs.npmjs.com/cli/v6/configuring-npm/package-json#engines