### PR TITLE
Replace Object.fromEntries with reduce for better Node support

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -31,7 +31,7 @@ exports.onPostBuild = async function ({ graphql }, config) {
     apiKey,
     queries,
     concurrentQueries = true,
-    skipIndexing = false
+    skipIndexing = false,
   } = config;
 
   const activity = report.activityTimer(`index to Algolia`);
@@ -402,7 +402,10 @@ async function getObjectsMapByQuery({ query, transformer }, graphql) {
   }
 
   // return a map by id for later use
-  return Object.fromEntries(objects.map(object => [object.objectID, object]));
+  return objects.reduce(
+    (acc, object) => ({ ...acc, [object.objectID]: object }),
+    {}
+  );
 }
 
 // get all match fields for all queries to minimize calls to the api


### PR DESCRIPTION
When attempting to deploy to an older environment (Node v10.23.0), I got the following error:

![Screen Shot 2020-12-07 at 4 04 16 PM](https://user-images.githubusercontent.com/1418487/101405389-008e8980-38a6-11eb-81c7-ab5180fce424.png)

Looks like it's due to the fact that `Object.fromEntries` wasn't introduced until Node v12. 

There are polyfills available, but `reduce` is used elsewhere in the same file so I figure it's probably a net gain to replace. Let me know if what you think, thanks!