### PR TITLE
feat: add continueOnError flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ module.exports = {
         matchFields: ['slug', 'modified'], // Array<String> default: ['modified']
         concurrentQueries: false, // default: true
         skipIndexing: true, // default: false, useful for e.g. preview deploys or local development
+        continueOnFailure: false // default: false, don't fail the build if algolia indexing fails
       },
     },
   ],

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -31,7 +31,8 @@ exports.onPostBuild = async function ({ graphql }, config) {
     apiKey,
     queries,
     concurrentQueries = true,
-    skipIndexing = false
+    skipIndexing = false,
+    continueOnFailure = false,
   } = config;
 
   const activity = report.activityTimer(`index to Algolia`);
@@ -71,7 +72,12 @@ exports.onPostBuild = async function ({ graphql }, config) {
 
     await Promise.all(jobs);
   } catch (err) {
-    report.panic('failed to index to Algolia', err);
+    if (continueOnFailure) {
+      report.warn('failed to index to Algolia')
+      console.error(err)
+    } else {
+      report.panic('failed to index to Algolia', err);
+    }
   }
 
   activity.end();


### PR DESCRIPTION
This will let the build continue even if Algolia indexing fails.