### PR TITLE
Fix index settings being wiped

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ const queries = [
     indexName: 'index name to target', // overrides main index name, optional
     settings: {
       // optional, any index settings
+      // Note: by supplying settings, you will overwrite all existing settings on the index
     },
     matchFields: ['slug', 'modified'], // Array<String> overrides main match fields, optional
   },
@@ -75,6 +76,7 @@ module.exports = {
         chunkSize: 10000, // default: 1000
         settings: {
           // optional, any index settings
+          // Note: by supplying settings, you will overwrite all existing settings on the index
         },
         enablePartialUpdates: true, // default: false
         matchFields: ['slug', 'modified'], // Array<String> default: ['modified']

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -351,7 +351,7 @@ async function getSettingsToApply({
   );
 
   const requestedSettings = {
-    ...(settings ? settings : existingSettings),
+    ...settings,
     replicas: replicasToSet,
   };
 


### PR DESCRIPTION
- Fixes https://github.com/algolia/gatsby-plugin-algolia/issues/110, where existing index settings are completely replaced on indexing, even if you don't pass any settings in. Now your existing settings will only be replaced if you provide them.
- Adds note to the example in the README to clarify behavior.

I manually tested providing settings and not providing settings to make sure the behavior is correct now. I did not test anything around replicas, but I don't see any reason why that would be affected. From what I can tell the replicas feature currently only works if you provide settings in the plugin, because of the reliance on `settings.replicaUpdateMode`.