### PR TITLE
fix(indexing): reference correct object for partial update no match field log message (#113)

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -174,7 +174,7 @@ async function runIndexQueries(
           if (!matchFields.every(field => newObj.hasOwnProperty(field))) {
             report.panic(
               'when enablePartialUpdates is true, the objects must have at least one of the match fields. Current object:\n' +
-                JSON.stringify(curObj, null, 2) +
+                JSON.stringify(newObj, null, 2) +
                 '\n' +
                 'expected one of these fields:\n' +
                 matchFields.join('\n')


### PR DESCRIPTION
This fixes an incorrect reference to the current object being parsed when used by the reporter.

Fixes #113 