### PR TITLE
feat(environment): Added functionality to perist entries from different instance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ module.exports = {
         matchFields: ['slug', 'modified'], // Array<String> default: ['modified']
         concurrentQueries: false, // default: true
         skipIndexing: true, // default: false, useful for e.g. preview deploys or local development
+        useEnvironment: 'blog', // default: false, used in conjunction with enablePartialUpdates let you persist entries from different environment
+        environmentKey: 'product', // default: 'environment', key used when useEnvironment is set.
       },
     },
   ],
@@ -126,6 +128,9 @@ For replica settings, extra care is taken to make sure only apply replicas to no
 If you pass `replicaUpdateMode: 'replace'` in the index settings, you can choose to update the replicas fully with those in the settings.
 
 If you pass `replicaUpdateMode: 'merge'` in the index settings, the replica settings will combine the replicas set on your dashboard with the additional ones you set via index settings here.
+
+### Persisting entries
+If you want to persist entries that are added to the index (for example added by the different gatsby instance if your index is combining several websites) you can set `useEnvironment` to unique string that represents given instance. All entries with different `environment` value will be ignored. You can change the key accordingly using `environmentKey`.
 
 ## Concurrent Queries
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -108,6 +108,8 @@ async function runIndexQueries(
     chunkSize = 1000,
     enablePartialUpdates = false,
     matchFields: mainMatchFields = ['modified'],
+    useEnvironment = false,
+    environmentKey = 'environment'
   } = config;
 
   setStatus(
@@ -168,6 +170,9 @@ async function runIndexQueries(
 
       // iterate over existing objects and compare to fresh data
       for (const [id, existingObj] of Object.entries(indexedObjects)) {
+        if (useEnvironment && existingObj[environmentKey] !== useEnvironment) {
+          continue;
+        }
         if (queryResultsMap.hasOwnProperty(id)) {
           // key matches fresh objects, so compare match fields
           const newObj = queryResultsMap[id];


### PR DESCRIPTION
*Context*
I am currently working on a project with federated search combining results from multiple gatsby instances. I've wanted to use this plugin but realized it is clearing all the results that did not appear in the new run. I've added an option to skip the results added from the different environment (i.e. different gatsby instance).