### PR TITLE
fix: Correct `reporter` usage + set correct peerDep, engines

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,5 @@
 const algoliasearch = require('algoliasearch');
 const chunk = require('lodash.chunk');
-const report = require('gatsby-cli/lib/reporter');
 const deepEqual = require('deep-equal');
 
 /**
@@ -26,7 +25,7 @@ function fetchAlgoliaObjects(index, attributesToRetrieve = ['modified']) {
   });
 }
 
-exports.onPostBuild = async function ({ graphql }, config) {
+exports.onPostBuild = async function({ graphql, reporter }, config) {
   const {
     appId,
     apiKey,
@@ -35,18 +34,18 @@ exports.onPostBuild = async function ({ graphql }, config) {
     skipIndexing = false,
   } = config;
 
-  const activity = report.activityTimer(`index to Algolia`);
+  const activity = reporter.activityTimer(`index to Algolia`);
   activity.start();
 
   if (skipIndexing === true) {
-    setStatus(activity, `options.skipIndexing is true; skipping indexing`);
+    activity.setStatus(`options.skipIndexing is true; skipping indexing`);
     activity.end();
     return;
   }
 
   const client = algoliasearch(appId, apiKey, { timeout: 30_000 });
 
-  setStatus(activity, `${queries.length} queries to index`);
+  activity.setStatus(`${queries.length} queries to index`);
 
   try {
     // combine queries with the same index to prevent overwriting data
@@ -59,6 +58,7 @@ exports.onPostBuild = async function ({ graphql }, config) {
         activity,
         graphql,
         config,
+        reporter,
       });
 
       if (concurrentQueries) {
@@ -72,7 +72,7 @@ exports.onPostBuild = async function ({ graphql }, config) {
 
     await Promise.all(jobs);
   } catch (err) {
-    report.panic('failed to index to Algolia', err);
+    activity.panicOnBuild('failed to index to Algolia', err);
   }
 
   activity.end();
@@ -102,7 +102,7 @@ function groupQueriesByIndex(queries = [], config) {
 async function runIndexQueries(
   indexName,
   queries = [],
-  { client, activity, graphql, config }
+  { client, activity, graphql, reporter, config },
 ) {
   const {
     settings: mainSettings,
@@ -111,12 +111,9 @@ async function runIndexQueries(
     matchFields: mainMatchFields = ['modified'],
   } = config;
 
-  setStatus(
-    activity,
-    `Running ${queries.length} ${
-      queries.length === 1 ? 'query' : 'queries'
-    } for index ${indexName}...`
-  );
+  activity.setStatus(`Running ${queries.length} ${
+    queries.length === 1 ? 'query' : 'queries'
+  } for index ${indexName}...`);
 
   const objectMapsByQuery = await Promise.all(
     queries.map(query => getObjectsMapByQuery(query, graphql))
@@ -129,12 +126,9 @@ async function runIndexQueries(
     };
   }, {});
 
-  setStatus(
-    activity,
-    `${queries.length === 1 ? 'Query' : 'Queries'} resulted in a total of ${
-      Object.keys(allObjectsMap).length
-    } results`
-  );
+  activity.setStatus(`${queries.length === 1 ? 'Query' : 'Queries'} resulted in a total of ${
+    Object.keys(allObjectsMap).length
+  } results`);
 
   const index = client.initIndex(indexName);
   const tempIndex = client.initIndex(`${indexName}_tmp`);
@@ -152,7 +146,7 @@ async function runIndexQueries(
     toIndex = { ...allObjectsMap };
   } else {
     // iterate over each query to determine which data are fresh
-    setStatus(activity, `Starting Partial updates...`);
+    activity.setStatus(`Starting Partial updates...`);
 
     // get all match fields for all queries to minimize calls to the api
     const allMatchFields = getAllMatchFields(queries, mainMatchFields);
@@ -173,7 +167,7 @@ async function runIndexQueries(
           // key matches fresh objects, so compare match fields
           const newObj = queryResultsMap[id];
           if (!matchFields.every(field => newObj.hasOwnProperty(field))) {
-            report.panic(
+            reporter.panicOnBuild(
               'when enablePartialUpdates is true, the objects must have at least one of the match fields. Current object:\n' +
                 JSON.stringify(newObj, null, 2) +
                 '\n' +
@@ -216,13 +210,10 @@ async function runIndexQueries(
   if (objectsToIndex.length) {
     const chunks = chunk(objectsToIndex, chunkSize);
 
-    setStatus(
-      activity,
-      `Found ${objectsToIndex.length} new / updated records...`
-    );
+    activity.setStatus(`Found ${objectsToIndex.length} new / updated records...`);
 
     if (chunks.length > 1) {
-      setStatus(activity, `Splitting in ${chunks.length} jobs`);
+      activity.setStatus(`Splitting in ${chunks.length} jobs`);
     }
 
     /* Add changed / new objects */
@@ -233,14 +224,11 @@ async function runIndexQueries(
 
     await Promise.all(chunkJobs);
   } else {
-    setStatus(activity, `No updates necessary; skipping!`);
+    activity.setStatus(`No updates necessary; skipping!`);
   }
 
   if (objectsToRemove.length) {
-    setStatus(
-      activity,
-      `Found ${objectsToRemove.length} stale objects; removing...`
-    );
+    activity.setStatus(`Found ${objectsToRemove.length} stale objects; removing...`);
 
     const { taskID } = await indexToUse.deleteObjects(objectsToRemove);
     await indexToUse.waitTask(taskID);
@@ -255,6 +243,7 @@ async function runIndexQueries(
     index,
     tempIndex,
     indexToUse,
+    reporter,
   });
 
   const { taskID } = await indexToUse.setSettings(settingsToApply, {
@@ -267,7 +256,7 @@ async function runIndexQueries(
     await moveIndex(client, indexToUse, index);
   }
 
-  setStatus(activity, 'Done!');
+  activity.setStatus('Done!');
 }
 
 /**
@@ -303,20 +292,6 @@ function indexExists(index) {
     });
 }
 
-/**
- * Hotfix the Gatsby reporter to allow setting status (not supported everywhere)
- *
- * @param {Object} activity reporter
- * @param {String} status status to report
- */
-function setStatus(activity, status) {
-  if (activity && activity.setStatus) {
-    activity.setStatus(status);
-  } else {
-    console.log('[Algolia]', status);
-  }
-}
-
 async function getIndexToUse({ index, tempIndex, enablePartialUpdates }) {
   const mainIndexExists = await indexExists(index);
 
@@ -331,9 +306,9 @@ async function getIndexToUse({ index, tempIndex, enablePartialUpdates }) {
   return index;
 }
 
-async function getSettingsToApply({ settings, index, tempIndex, indexToUse }) {
+async function getSettingsToApply({ settings, index, tempIndex, indexToUse, reporter }) {
   const existingSettings = await index.getSettings().catch(e => {
-    report.panic(`${e.toString()} ${index.indexName}`);
+    reporter.panicOnBuild(`${e.toString()} ${index.indexName}`);
   });
 
   if (!settings) {
@@ -378,10 +353,10 @@ function getReplicasToSet(
   }
 }
 
-async function getObjectsMapByQuery({ query, transformer }, graphql) {
+async function getObjectsMapByQuery({ query, transformer, reporter }, graphql) {
   const result = await graphql(query);
   if (result.errors) {
-    report.panic(
+    reporter.panicOnBuild(
       `failed to index to Algolia, errors:\n ${JSON.stringify(result.errors)}`,
       result.errors
     );
@@ -393,8 +368,8 @@ async function getObjectsMapByQuery({ query, transformer }, graphql) {
   }));
 
   if (objects.length > 0 && !objects[0].objectID) {
-    report.panic(
-      `failed to index to Algolia. Query results do not have 'objectID' or 'id' key`
+    reporter.panicOnBuild(
+      `failed to index to Algolia. Query results do not have 'objectID' or 'id' key`,
     );
   }
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -116,7 +116,7 @@ async function runIndexQueries(
   } for index ${indexName}...`);
 
   const objectMapsByQuery = await Promise.all(
-    queries.map(query => getObjectsMapByQuery(query, graphql))
+    queries.map(query => getObjectsMapByQuery(query, graphql, reporter))
   );
 
   const allObjectsMap = objectMapsByQuery.reduce((acc, objectsMap = {}) => {
@@ -353,7 +353,7 @@ function getReplicasToSet(
   }
 }
 
-async function getObjectsMapByQuery({ query, transformer, reporter }, graphql) {
+async function getObjectsMapByQuery({ query, transformer }, graphql, reporter) {
   const result = await graphql(query);
   if (result.errors) {
     reporter.panicOnBuild(

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "lodash.chunk": "^4.2.0"
   },
   "peerDependencies": {
-    "gatsby-cli": "> 1.1.58 < 4"
+    "gatsby": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "standard-version": "^4.4.0"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=12.13.0"
   },
   "scripts": {
     "release": "standard-version"


### PR DESCRIPTION
Hello, Gatsby maintainer here 👋 

While looking at the plugin I noticed that the `peerDependency` is set incorrectly. It should be a dependency on `gatsby` and not `gatsby-cli`. We're in the process of providing more helpful information on the `/plugins` page of our website and for that we need plugins to set their `peerDependencies` correctly/more specific.

I've also updated the minimum Node version as v3 requires at least 12.13.0.

Thanks!

Fixes https://github.com/algolia/gatsby-plugin-algolia/issues/123
Fixes https://github.com/algolia/gatsby-plugin-algolia/issues/126
Fixes https://github.com/algolia/gatsby-plugin-algolia/issues/97