### PR TITLE
fix: import graphql tag explicitly

### DIFF
--- a/example/src/layouts/index.js
+++ b/example/src/layouts/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { graphql } from "gatsby"
 
 import Header from '../components/header'
 import './index.css'


### PR DESCRIPTION
In [Gatsby v3](https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3/#using-a-global-graphql-tag-for-queries) the graphql tag needs to be imported explicitly.