### PR TITLE
fix: copy rules to temporary index to avoid losing them

### DIFF
--- a/example/gatsby-config.js
+++ b/example/gatsby-config.js
@@ -53,6 +53,7 @@ module.exports = {
         queries,
         chunkSize: 10000, // default: 1000
         enablePartialUpdates: true, // default: false
+        copyRules: true, // you may wish to keep the index rules when creating it
         matchFields: ['contentDigest'],
       },
     },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -138,6 +138,7 @@ async function runIndexQueries(
     settings: mainSettings,
     chunkSize = 1000,
     enablePartialUpdates = false,
+    copyRules = false,
     matchFields: mainMatchFields = ['modified'],
   } = config;
 
@@ -171,6 +172,12 @@ async function runIndexQueries(
     tempIndex,
     enablePartialUpdates,
   });
+
+   // copy any rules to the new temp index
+   if (copyRules) {
+    activity.setStatus(`Copying Rules!`);
+    await client.copyRules(index.indexName,tempIndex.indexName).wait();
+  }
 
   let toIndex = {}; // used to track objects that should be added / updated
   const toRemove = {}; // used to track objects that are stale and should be removed


### PR DESCRIPTION
Hello, 

Rules have become an important feature for algolia which allow users to modify search results: https://www.algolia.com/doc/api-client/methods/rules/

The method used by this plugin creates a temporary index that later is copied to the main index. If you have any active rule it will be pruned whenever this process is executed. This can become a problem as users would lose created rules and would have to manually recreated them.

This pull request adds an extra option and copy the rules from the origin index to the temporary index, then the `moveindex` function which is executed later will also copy the rules to the final index.

I did some tests locally and everything works fine but did not do any automated test. I am not sure if this has any potential impact of breaking stuff (Copy rules that depends on data that have been removed, for example) but as we can easily enable it using `copyRules` property I believe it would be a good intermediate solution for people that are facing the same problem as me.

Please let me know if you have any questions. 

If approved to we have a timeframe for a new release?

Thanks
