### PR TITLE
Fix #150 - Creates index if it does not exist

### DIFF
--- a/example/gatsby-config.js
+++ b/example/gatsby-config.js
@@ -31,6 +31,7 @@ const queries = [
     // optional
     // indexName: 'pages',
     // optional
+    indexName: 'test_index',
     settings: {
       attributesToSnippet: ['path:5', 'internal'],
     },
@@ -49,7 +50,6 @@ module.exports = {
       options: {
         appId: process.env.ALGOLIA_APPID,
         apiKey: process.env.ALGOLIA_APIKEY,
-        indexName: process.env.ALGOLIA_INDEXNAME, // for all queries
         queries,
         chunkSize: 10000, // default: 1000
         enablePartialUpdates: true, // default: false

--- a/example/gatsby-config.js
+++ b/example/gatsby-config.js
@@ -31,7 +31,6 @@ const queries = [
     // optional
     // indexName: 'pages',
     // optional
-    indexName: 'test_index',
     settings: {
       attributesToSnippet: ['path:5', 'internal'],
     },
@@ -50,6 +49,7 @@ module.exports = {
       options: {
         appId: process.env.ALGOLIA_APPID,
         apiKey: process.env.ALGOLIA_APIKEY,
+        indexName: process.env.ALGOLIA_INDEXNAME, // for all queries
         queries,
         chunkSize: 10000, // default: 1000
         enablePartialUpdates: true, // default: false

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -105,6 +105,7 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
 
     await Promise.all(jobs);
   } catch (err) {
+      console.log("got error", error, JSON.stringify(error))
     if (continueOnFailure) {
       reporter.warn('failed to index to Algolia');
       console.error(err);
@@ -181,11 +182,11 @@ async function runIndexQueries(
     } results`
   );
 
-  const index = client.initIndex(indexName);
+  let index = client.initIndex(indexName);
   const tempIndex = client.initIndex(`${indexName}_tmp`);
 
-  if (!indexExists(index)) {
-    await createIndex(index)
+  if (!await indexExists(index)) {
+    index = await createIndex(index)
   }
 
   const indexToUse = await getIndexToUse({

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -183,6 +183,11 @@ async function runIndexQueries(
 
   const index = client.initIndex(indexName);
   const tempIndex = client.initIndex(`${indexName}_tmp`);
+
+  if (!indexExists(index)) {
+    await createIndex(index)
+  }
+
   const indexToUse = await getIndexToUse({
     index,
     tempIndex,
@@ -376,7 +381,7 @@ function indexExists(index) {
     .getSettings()
     .then(() => true)
     .catch(error => {
-      if (error.statusCode !== 404) {
+      if (error.status !== 404) {
         throw error;
       }
 
@@ -392,13 +397,7 @@ function indexExists(index) {
  * @returns {Promise<import('algoliasearch').SearchIndex>}
  */
 async function getIndexToUse({ index, tempIndex, enablePartialUpdates }) {
-  const mainIndexExists = await indexExists(index);
-
-  if (enablePartialUpdates && !mainIndexExists) {
-    return createIndex(index);
-  }
-
-  if (!enablePartialUpdates && mainIndexExists) {
+  if (!enablePartialUpdates) {
     return tempIndex;
   }
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -105,7 +105,6 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
 
     await Promise.all(jobs);
   } catch (err) {
-      console.log("got error", error, JSON.stringify(error))
     if (continueOnFailure) {
       reporter.warn('failed to index to Algolia');
       console.error(err);


### PR DESCRIPTION
There were a couple issues with the code related to #150 .  This PR fixes both.

- Fixed `indexExists` function to check for HTTP status code under the `error.status` property rather than `error.statusCode`
- Creating `index` if it doesn't exist _every time_ since we always want it to be created if it does not exist.  There are several places in the code that blow up if the index does not exist.