### PR TITLE
Removing redundant setSettings call

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -336,16 +336,6 @@ async function runIndexQueries(
       .wait();
   }
 
-  if (dryRun) {
-    console.log('[dry run]: settings', settingsToApply);
-  } else {
-    await indexToUse
-      .setSettings(settingsToApply, {
-        forwardToReplicas,
-      })
-      .wait();
-  }
-
   if (indexToUse === tempIndex && dryRun === false) {
     await moveIndex(client, indexToUse, index);
   }


### PR DESCRIPTION
Looks like this code was accidentally duplicated as part of a previous PR.  I see no reason that this code should have to run twice.