### PR TITLE
Adding merge settings option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ const queries = [
       // Note: by supplying settings, you will overwrite all existing settings on the index
     },
     matchFields: ['slug', 'modified'], // Array<String> overrides main match fields, optional
+    mergeSettings: false, // optional, defaults to false.  See notes on mergeSettings below
   },
 ];
 
@@ -130,6 +131,14 @@ You can also specify `matchFields` per query to check for different fields based
 ## Settings
 
 You can set settings for each index individually (per query), or otherwise it will keep your existing settings.
+
+### Merge Settings
+
+`mergeSettings` allows you to preserve settings changes made on the Algolia website.  The default behavior (`mergeSettings: false`) will wipe out your index settings and replace them with settings from the config on each build.
+
+When set to true, the config index settings will be merged with the existing index settings in Algolia (with the config index settings taking precendence).
+
+NOTE: When using `mergeSettings`, any **deleted** settings from the config settings will continue to be persisted since they will still exist in Algolia. If you want to remove a setting, be sure to remove it from both the config and on Algolia's website.
 
 ### Replicas
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -316,10 +316,11 @@ async function runIndexQueries(
 
   // defer to first query for index settings
   // todo: maybe iterate over all settings and throw if they differ
-  const { settings = mainSettings, forwardToReplicas } = queries[0] || {};
+  const { settings = mainSettings, mergeSettings = false, forwardToReplicas } = queries[0] || {};
 
   const settingsToApply = await getSettingsToApply({
     settings,
+    mergeSettings,
     index,
     tempIndex,
     indexToUse,
@@ -407,6 +408,7 @@ async function getIndexToUse({ index, tempIndex, enablePartialUpdates }) {
 /**
  * @param {object} options
  * @param {import('@algolia/client-search').Settings} options.settings
+ * @param {boolean} query.mergeSettings
  * @param {import('algoliasearch').SearchIndex} options.index
  * @param {import('algoliasearch').SearchIndex} options.tempIndex
  * @param {import('algoliasearch').SearchIndex} options.indexToUse
@@ -415,6 +417,7 @@ async function getIndexToUse({ index, tempIndex, enablePartialUpdates }) {
  */
 async function getSettingsToApply({
   settings,
+  mergeSettings,
   index,
   tempIndex,
   indexToUse,
@@ -435,6 +438,7 @@ async function getSettingsToApply({
   );
 
   const { replicaUpdateMode, ...requestedSettings } = {
+    ...(mergeSettings ? existingSettings : {}),
     ...settings,
     replicas: replicasToSet,
   };


### PR DESCRIPTION
# Adding `mergeSettings`
The `mergeSettings` option will merge whatever settings you have with the existing index settings.  The settings defined for the query will take precedence.

### Why?
This allows you to make index changes using the Algolia web interface and to preserve those changes.  Currently, any changes you make through the Algolia web interface are overwritten anytime this plugin runs.