### PR TITLE
Allow installation with Gatsby 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lodash.chunk": "^4.2.0"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "standard-version": "^4.4.0"


### PR DESCRIPTION
This simply adds version 4 to the `gatsby` peer dependencies. I've done some basic testing on my existing site with this and it appears to work fine with no additional changes required.