### PR TITLE
fix: avoid indexes to get empty copies when multiple builds are happening

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -182,10 +182,12 @@ async function runIndexQueries(
   );
 
   let index = client.initIndex(indexName);
-  const tempIndex = client.initIndex(`${indexName}_tmp`);
 
-  if (!await indexExists(index)) {
-    index = await createIndex(index)
+  const randomTemp = `temp${Math.floor(Math.random() * 100 + 1)}`;
+  const tempIndex = client.initIndex(`${indexName}_${randomTemp}`);
+
+  if (!(await indexExists(index))) {
+    index = await createIndex(index);
   }
 
   const indexToUse = await getIndexToUse({


### PR DESCRIPTION
## Problem
- Every once in a while the indexed products in Algolia would disappear completely.
- We contacted Algolia and after their investigation, they responded that the problem was within the plugin.
- The trigger was when there were multiple deploy processes.

### Algolia's technical answer
"What happened this time is that you had multiple hosts executing these steps in parallel.

- Host A sent records to the `dev_NAME_tmp` index, which was created at this point.
- Host A updated index setting of the `dev_NAME_tmp` index.
- Host B sent records to the `dev_NAME_tmp` index.
- Host A renamed `dev_NAME_tmp` to `dev_NAME`.
- Host B updated the index setting of the dev_NAME_tmp index. This creates NEW `dev_NAME_tmp` without records.
- Host A renamed `dev_NAME_tmp` to `dev_NAME` again, which eventually overwrote the production index with the empty index."

## Solution
The solution was to change the `tempIndex`'s suffix in the algolia-gatsby plugin to randomize the name of the temporary index

## Changes
Randomize the suffix of the `tempIndex` name up to 100 to avoid collapses when there are parallel builds 