### PR TITLE
feat(config): Allow options to be passed to algoliasearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ module.exports = {
         concurrentQueries: false, // default: true
         skipIndexing: true, // default: false, useful for e.g. preview deploys or local development
         continueOnFailure: false, // default: false, don't fail the build if algolia indexing fails
+        algoliasearchOptions: undefined, // default: { timeouts: { connect: 1, read: 30, write: 30 } }, pass any different options to the algoliasearch constructor
       },
     },
   ],

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -41,7 +41,13 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
     skipIndexing = false,
     dryRun = false,
     continueOnFailure = false,
-    requester = null,
+    algoliasearchOptions = {
+      timeouts: {
+        connect: 1,
+        read: 30,
+        write: 30,
+      },
+    },
   } = config;
 
   const activity = reporter.activityTimer(`index to Algolia`);
@@ -70,19 +76,7 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
     return;
   }
 
-  const clientOptions = {
-    timeouts: {
-      connect: 1,
-      read: 30,
-      write: 30,
-    },
-  };
-
-  if (requester) {
-    clientOptions.requester = requester;
-  }
-
-  const client = algoliasearch(appId, apiKey, clientOptions);
+  const client = algoliasearch(appId, apiKey, algoliasearchOptions);
 
   activity.setStatus(`${queries.length} queries to index`);
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -41,6 +41,7 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
     skipIndexing = false,
     dryRun = false,
     continueOnFailure = false,
+    requester = null,
   } = config;
 
   const activity = reporter.activityTimer(`index to Algolia`);
@@ -69,13 +70,19 @@ exports.onPostBuild = async function ({ graphql, reporter }, config) {
     return;
   }
 
-  const client = algoliasearch(appId, apiKey, {
+  const clientOptions = {
     timeouts: {
       connect: 1,
       read: 30,
       write: 30,
     },
-  });
+  };
+
+  if (requester) {
+    clientOptions.requester = requester;
+  }
+
+  const client = algoliasearch(appId, apiKey, clientOptions);
 
   activity.setStatus(`${queries.length} queries to index`);
 


### PR DESCRIPTION
We're using a corporate proxy and cannot make `gatsby-plugin-algolia` work without passing a custom requester.

I found this PR (https://github.com/algolia/algoliasearch-client-javascript/pull/1180) where `createNodeHttpRequester` was extended to pass a custom HTTP agent.
With this change you can pass an optional custom requester to `gatsby-plugin-algolia` which resolved our issue.

Feedback is welcome. Let me know if I still need to change/add something. 
Thanks in advance!

Bart (from 🇧🇪)